### PR TITLE
turn off a message complaining about X11 or headless

### DIFF
--- a/plantuml
+++ b/plantuml
@@ -1,4 +1,3 @@
 #! /bin/sh
 
-exec java -jar /opt/plantuml/plantuml.jar "$@"
-
+exec java -Djava.awt.headless=true -jar /opt/plantuml/plantuml.jar "$@"


### PR DESCRIPTION
From http://plantuml.com/faq.html#headless:

> If you are running PlantUML on a linux server without graphical capability, you may have some error message: 
> Can't connect to X11 window
> X11 connection rejected because of wrong authentication.
> HeadlessException
> 
> Basically, this is because PlantUML needs to have access to some graphical resources (more information here). 
> You can turn PlantUML to headless mode, using the flag -Djava.awt.headless=true. 
> For example:
> /usr/bin/java -Djava.awt.headless=true -jar /data/PlantUml/plantuml.jar ...
